### PR TITLE
IO bottleneck

### DIFF
--- a/app/pipeline_runner.cpp
+++ b/app/pipeline_runner.cpp
@@ -13,8 +13,8 @@ using namespace std::chrono_literals;
 
 int main(int argc, char *argv[])
 {
-    spdlog::set_level(spdlog::level::critical);
-    Pipeline p(4);
+    spdlog::set_level(spdlog::level::info);
+    Pipeline p(64);
     std::vector<std::string> files;
 
     if (argc > 1)
@@ -37,5 +37,5 @@ int main(int argc, char *argv[])
     auto to_wgs84 = [&p](const Eigen::Vector3d& local) { return p.getCoord().toWGS84(local); };
     std::string out = toVisualizedGeoJson(p.getGraph(), to_wgs84);
 
-    std::cout << out << std::endl;
+    std::cerr << out << std::endl;
 }

--- a/app/pipeline_runner.cpp
+++ b/app/pipeline_runner.cpp
@@ -5,8 +5,8 @@
 #include <spdlog/spdlog.h>
 
 #include <filesystem>
-#include <thread>
 #include <iostream>
+#include <thread>
 
 using namespace opencalibration;
 using namespace std::chrono_literals;
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
         std::this_thread::sleep_for(1ms);
     }
 
-    auto to_wgs84 = [&p](const Eigen::Vector3d& local) { return p.getCoord().toWGS84(local); };
+    auto to_wgs84 = [&p](const Eigen::Vector3d &local) { return p.getCoord().toWGS84(local); };
     std::string out = toVisualizedGeoJson(p.getGraph(), to_wgs84);
 
     std::cerr << out << std::endl;

--- a/include/opencalibration/pipeline/link_stage.hpp
+++ b/include/opencalibration/pipeline/link_stage.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <opencalibration/pipeline/pipeline.hpp>
+
+namespace opencalibration
+{
+
+class BuildLinksStage
+{
+    struct inlier_measurement
+    {
+        size_t node_id;
+        size_t match_node_id;
+        camera_relations relations;
+    };
+
+  public:
+    void init(const MeasurementGraph &graph, const jk::tree::KDTree<size_t, 3> &imageGPSLocations,
+              const std::vector<size_t> &node_ids);
+
+    std::vector<std::function<void()>> get_runners(const MeasurementGraph &graph);
+
+    void finalize(MeasurementGraph &graph);
+
+  private:
+    std::vector<inlier_measurement> _all_inlier_measurements;
+    std::mutex _measurement_mutex;
+
+    std::vector<NodeLinks> _links;
+};
+
+} // namespace opencalibration

--- a/include/opencalibration/pipeline/load_stage.hpp
+++ b/include/opencalibration/pipeline/load_stage.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <opencalibration/pipeline/pipeline.hpp>
+
+namespace opencalibration
+{
+
+class LoadStage
+{
+  public:
+    void init(const std::vector<std::string> &paths_to_load);
+    std::vector<std::function<void()>> get_runners();
+    std::vector<size_t> finalize(GeoCoord &coordinate_system, MeasurementGraph &graph,
+                                 jk::tree::KDTree<size_t, 3> &imageGPSLocations);
+
+  private:
+    std::mutex _images_mutex;
+    std::vector<image> _images;
+
+    std::vector<std::string> _paths_to_load;
+};
+} // namespace opencalibration

--- a/include/opencalibration/pipeline/pipeline.hpp
+++ b/include/opencalibration/pipeline/pipeline.hpp
@@ -39,7 +39,7 @@ class Pipeline
 
   private:
 
-    void process_images(const std::vector<std::string> &paths);
+    void process_images(const std::vector<size_t> &loaded_ids, const std::vector<std::string> &paths_to_load, std::vector<size_t>& next_ids);
     std::vector<size_t> build_nodes(const std::vector<std::string> &paths);
 
     struct NodeLinks

--- a/include/opencalibration/pipeline/pipeline.hpp
+++ b/include/opencalibration/pipeline/pipeline.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-
-#include <opencalibration/relax/relax.hpp>
 #include <opencalibration/geo_coord/geo_coord.hpp>
+#include <opencalibration/relax/relax.hpp>
 
 #include <jk/KDTree.h>
 
@@ -16,6 +15,11 @@
 
 namespace opencalibration
 {
+struct NodeLinks
+{
+    size_t node_id;
+    std::vector<size_t> link_ids;
+};
 
 class Pipeline
 {
@@ -33,24 +37,16 @@ class Pipeline
 
     void add(const std::vector<std::string> &filename);
 
-    const MeasurementGraph& getGraph(); // warning - not threadsafe
+    const MeasurementGraph &getGraph(); // warning - not threadsafe
 
-    const GeoCoord& getCoord() const { return _coordinate_system; }
+    const GeoCoord &getCoord() const
+    {
+        return _coordinate_system;
+    }
 
   private:
-
-    void process_images(const std::vector<size_t> &loaded_ids, const std::vector<std::string> &paths_to_load, std::vector<size_t>& next_ids);
-    std::vector<size_t> build_nodes(const std::vector<std::string> &paths);
-
-    struct NodeLinks
-    {
-        size_t node_id;
-        std::vector<size_t> link_ids;
-    };
-
-    std::vector<NodeLinks> find_links(const std::vector<size_t>& node_ids);
-    void process_links(const std::vector<NodeLinks>& links);
-
+    void process_images(const std::vector<size_t> &loaded_ids, const std::vector<std::string> &paths_to_load,
+                        std::vector<size_t> &next_ids);
 
     std::condition_variable _queue_condition_variable;
     std::mutex _queue_mutex;
@@ -75,6 +71,5 @@ class Pipeline
     MeasurementGraph _graph;
     jk::tree::KDTree<size_t, 3> _imageGPSLocations;
     GeoCoord _coordinate_system;
-
 };
 } // namespace opencalibration

--- a/src/pipeline/CMakeLists.txt
+++ b/src/pipeline/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_library(oc_pipeline pipeline.cpp)
+add_library(oc_pipeline pipeline.cpp
+                        load_stage.cpp
+                        link_stage.cpp)
 target_link_libraries(oc_pipeline PUBLIC oc_extract
                                           oc_match
                                           oc_distort

--- a/src/pipeline/link_stage.cpp
+++ b/src/pipeline/link_stage.cpp
@@ -1,0 +1,132 @@
+#include <opencalibration/pipeline/link_stage.hpp>
+
+#include <opencalibration/distort/distort_keypoints.hpp>
+#include <opencalibration/match/match_features.hpp>
+#include <opencalibration/model_inliers/ransac.hpp>
+
+#include <spdlog/spdlog.h>
+
+namespace
+{
+
+std::array<double, 3> to_array(const Eigen::Vector3d &v)
+{
+    return {v.x(), v.y(), v.z()};
+}
+} // namespace
+
+namespace opencalibration
+{
+
+void BuildLinksStage::init(const MeasurementGraph &graph, const jk::tree::KDTree<size_t, 3> &imageGPSLocations,
+                           const std::vector<size_t> &node_ids)
+{
+    spdlog::info("Queueing {} image nodes for link building", node_ids.size());
+    _links.clear();
+    _links.reserve(node_ids.size());
+
+    // build nearest in serial, since it is really fast
+    for (size_t node_id : node_ids)
+    {
+        const auto &img = graph.getNode(node_id)->payload;
+
+        auto knn = imageGPSLocations.searchKnn(to_array(img.position), 10);
+        NodeLinks link;
+        link.node_id = node_id;
+        link.link_ids.reserve(knn.size());
+        for (const auto &nn : knn)
+        {
+            if (nn.payload != node_id)
+            {
+                link.link_ids.push_back(nn.payload);
+            }
+        }
+        _links.emplace_back(std::move(link));
+    }
+}
+
+std::vector<std::function<void()>> BuildLinksStage::get_runners(const MeasurementGraph &graph)
+{
+    std::vector<std::function<void()>> funcs;
+    funcs.reserve(_links.size());
+    _all_inlier_measurements.reserve(10 * _links.size());
+    for (size_t i = 0; i < _links.size(); i++)
+    {
+        auto run_func = [&, i]() {
+            const auto &node_nearest = _links[i];
+            size_t node_id = node_nearest.node_id;
+            const auto &img = graph.getNode(node_id)->payload;
+            const auto &nearest = node_nearest.link_ids;
+
+            // match & distort
+            std::vector<std::tuple<size_t, std::reference_wrapper<const image>>> nearest_images;
+            nearest_images.reserve(nearest.size());
+            for (size_t match_node_id : nearest)
+            {
+                const auto *node = graph.getNode(match_node_id);
+                if (node != nullptr)
+                {
+                    nearest_images.emplace_back(match_node_id, node->payload);
+                }
+            }
+
+            for (const auto &near_image : nearest_images)
+            {
+                // match
+                auto matches = match_features(img.features, std::get<1>(near_image).get().features);
+
+                // distort
+                std::vector<correspondence> correspondences =
+                    distort_keypoints(img.features, std::get<1>(near_image).get().features, matches, img.model,
+                                      std::get<1>(near_image).get().model);
+
+                // ransac
+                homography_model h;
+                std::vector<bool> inliers;
+                ransac(correspondences, h, inliers);
+
+                camera_relations relations;
+                relations.ransac_relation = h.homography;
+                relations.relationType = camera_relations::RelationType::HOMOGRAPHY;
+
+                bool can_decompose =
+                    h.decompose(correspondences, inliers, relations.relative_rotation, relations.relative_translation);
+
+                size_t num_inliers = std::count(inliers.begin(), inliers.end(), true);
+
+                spdlog::debug("Matches: {}  inliers: {}  can_decompose: {}", matches.size(), num_inliers,
+                              can_decompose);
+                if (can_decompose && num_inliers > h.MINIMUM_POINTS * 1.5)
+                {
+                    relations.inlier_matches.reserve(num_inliers);
+                    for (size_t i = 0; i < inliers.size(); i++)
+                    {
+                        if (inliers[i])
+                        {
+                            feature_match_denormalized fmd;
+                            fmd.pixel_1 = img.features[matches[i].feature_index_1].location;
+                            fmd.pixel_2 = std::get<1>(near_image).get().features[matches[i].feature_index_2].location;
+                            relations.inlier_matches.push_back(fmd);
+                        }
+                    }
+                    std::lock_guard<std::mutex> lock(_measurement_mutex);
+                    _all_inlier_measurements.emplace_back(
+                        inlier_measurement{node_id, std::get<0>(near_image), std::move(relations)});
+                }
+            }
+        };
+        funcs.push_back(run_func);
+    }
+    return funcs;
+}
+
+void BuildLinksStage::finalize(MeasurementGraph &graph)
+{
+    for (auto &measurements : _all_inlier_measurements)
+    {
+        graph.addEdge(std::move(measurements.relations), measurements.node_id, measurements.match_node_id);
+    }
+    _all_inlier_measurements.clear();
+}
+
+} // namespace opencalibration

--- a/src/pipeline/load_stage.cpp
+++ b/src/pipeline/load_stage.cpp
@@ -1,0 +1,86 @@
+#include <opencalibration/pipeline/load_stage.hpp>
+
+#include <opencalibration/extract/extract_features.hpp>
+#include <opencalibration/extract/extract_metadata.hpp>
+
+#include <spdlog/spdlog.h>
+
+namespace
+{
+std::array<double, 3> to_array(const Eigen::Vector3d &v)
+{
+    return {v.x(), v.y(), v.z()};
+}
+} // namespace
+
+namespace opencalibration
+{
+
+void LoadStage::init(const std::vector<std::string> &paths_to_load)
+{
+    spdlog::info("Queueing {} image paths for loading", paths_to_load.size());
+    _paths_to_load = paths_to_load;
+    _images.clear();
+    _images.reserve(_paths_to_load.size());
+}
+std::vector<std::function<void()>> LoadStage::get_runners()
+{
+    std::vector<std::function<void()>> funcs;
+    funcs.reserve(_paths_to_load.size());
+    for (size_t i = 0; i < _paths_to_load.size(); i++)
+    {
+        auto run_func = [&, i]() {
+            const std::string &path = _paths_to_load[i];
+            image img;
+            img.path = path;
+            img.features = extract_features(img.path);
+            if (img.features.size() == 0)
+            {
+                return;
+            }
+
+            img.metadata = extract_metadata(img.path);
+            img.model.focal_length_pixels = img.metadata.focal_length_px;
+            img.model.pixels_cols = img.metadata.width_px;
+            img.model.pixels_rows = img.metadata.height_px;
+            img.model.principle_point = Eigen::Vector2d(img.model.pixels_cols, img.model.pixels_rows) / 2;
+
+            spdlog::debug("camera model: dims: {}x{} focal: {}", img.model.pixels_cols, img.model.pixels_rows,
+                          img.model.focal_length_pixels);
+
+            std::lock_guard<std::mutex> lock(_images_mutex);
+            _images.push_back(std::move(img));
+        };
+        funcs.push_back(run_func);
+    }
+
+    return funcs;
+}
+std::vector<size_t> LoadStage::finalize(GeoCoord &coordinate_system, MeasurementGraph &graph,
+                                        jk::tree::KDTree<size_t, 3> &imageGPSLocations)
+{
+    // put the images back in order after the parallel processing
+    std::sort(_images.begin(), _images.end(),
+              [this](const image &img1, const image &img2) -> int { return img1.path < img2.path; });
+
+    std::vector<size_t> node_ids;
+    node_ids.reserve(_paths_to_load.size());
+
+    for (auto &img : _images)
+    {
+        if (!coordinate_system.isInitialized())
+        {
+            coordinate_system.setOrigin(img.metadata.latitude, img.metadata.longitude);
+        }
+
+        Eigen::Vector3d local_pos = img.position =
+            coordinate_system.toLocalCS(img.metadata.latitude, img.metadata.longitude, img.metadata.altitude);
+        size_t node_id = graph.addNode(std::move(img));
+        imageGPSLocations.addPoint(to_array(local_pos), node_id);
+        node_ids.push_back(node_id);
+    }
+
+    return node_ids;
+}
+
+} // namespace opencalibration

--- a/src/pipeline/pipeline.cpp
+++ b/src/pipeline/pipeline.cpp
@@ -7,6 +7,7 @@
 #include <opencalibration/model_inliers/ransac.hpp>
 
 #include <spdlog/spdlog.h>
+#include <omp.h>
 
 #include <chrono>
 #include <iostream>
@@ -26,6 +27,7 @@ namespace opencalibration
 Pipeline::Pipeline(size_t batch_size)
 {
     _keep_running = true;
+    omp_set_num_threads(batch_size);
     auto get_paths = [this, batch_size](std::vector<std::string> &paths, ThreadStatus &status) -> bool {
         while (_add_queue.size() > 0 && paths.size() < batch_size)
         {
@@ -47,13 +49,18 @@ Pipeline::Pipeline(size_t batch_size)
     _runner.thread.reset(new std::thread([this, batch_size, get_paths]() {
         std::mutex sleep_mutex;
         std::vector<std::string> paths;
+        std::vector<size_t> loaded_ids, next_ids;
         paths.reserve(batch_size);
+        loaded_ids.reserve(batch_size);
+        next_ids.reserve(batch_size);
         while (_keep_running)
         {
             paths.clear();
-            if (get_paths(paths, _runner.status))
+            next_ids.clear();
+            if (get_paths(paths, _runner.status) || loaded_ids.size() > 0)
             {
-                process_images(paths);
+                process_images(loaded_ids, paths, next_ids);
+                std::swap(loaded_ids, next_ids);
             }
             else
             {
@@ -74,79 +81,165 @@ Pipeline::~Pipeline()
     }
 }
 
-void Pipeline::process_images(const std::vector<std::string> &paths)
+void Pipeline::process_images(const std::vector<size_t> &loaded_ids, const std::vector<std::string> &paths_to_load, std::vector<size_t>& next_ids)
 {
-    spdlog::info("Loading batch of {}", paths.size());
-    for (const auto &path : paths)
-        spdlog::debug(path);
-
-    const std::vector<size_t> node_ids = build_nodes(paths);
     spdlog::info("Building links");
-    const std::vector<NodeLinks> links = find_links(node_ids);
-    for (const auto &link : links)
-    {
-        spdlog::debug("Node: {}", link.node_id);
-        spdlog::debug("Links to:");
-        for (size_t neighbor : link.link_ids)
-            spdlog::debug("{:>30}", neighbor);
+    const std::vector<NodeLinks> links = find_links(loaded_ids);
+    
+    std::vector<std::function<void()>> funcs;
+    funcs.reserve(paths_to_load.size() + links.size());
+
+    { 
+        for (const auto &link : links)
+        {
+            spdlog::debug("Node: {}", link.node_id);
+            spdlog::debug("Links to:");
+            for (size_t neighbor : link.link_ids)
+                spdlog::debug("{:>30}", neighbor);
+        }
+//             process_links(links);
+        for (size_t i = 0; i < links.size(); i++)
+        {
+            auto run_func = [&,i](){
+                const auto &node_nearest = links[i];
+                size_t node_id = node_nearest.node_id;
+                const auto &img = _graph.getNode(node_id)->payload;
+                const auto &nearest = node_nearest.link_ids;
+
+                // match & distort
+                std::vector<std::tuple<size_t, CameraModel, std::vector<feature_2d>>> nearest_descriptors;
+                nearest_descriptors.reserve(nearest.size());
+                for (size_t match_node_id : nearest)
+                {
+                    const auto *node = _graph.getNode(match_node_id);
+                    if (node != nullptr)
+                    {
+                        nearest_descriptors.emplace_back(match_node_id, node->payload.model, node->payload.features);
+                    }
+                }
+                std::vector<std::pair<size_t, camera_relations>> inlier_measurements;
+                inlier_measurements.reserve(nearest_descriptors.size());
+                for (const auto &node_descriptors : nearest_descriptors)
+                {
+                    // match
+                    auto matches = match_features(img.features, std::get<2>(node_descriptors));
+
+                    // distort
+                    std::vector<correspondence> correspondences = distort_keypoints(
+                        img.features, std::get<2>(node_descriptors), matches, img.model, std::get<1>(node_descriptors));
+
+                    // ransac
+                    homography_model h;
+                    std::vector<bool> inliers;
+                    ransac(correspondences, h, inliers);
+
+                    camera_relations relations;
+                    relations.ransac_relation = h.homography;
+                    relations.relationType = camera_relations::RelationType::HOMOGRAPHY;
+
+                    bool can_decompose =
+                        h.decompose(correspondences, inliers, relations.relative_rotation, relations.relative_translation);
+
+                    size_t num_inliers = std::count(inliers.begin(), inliers.end(), true);
+
+                    spdlog::debug("Matches: {}  inliers: {}  can_decompose: {}", matches.size(), num_inliers, can_decompose);
+                    if (can_decompose && num_inliers > h.MINIMUM_POINTS * 1.5)
+                    {
+                        relations.inlier_matches.reserve(num_inliers);
+                        for (size_t i = 0; i < inliers.size(); i++)
+                        {
+                            if (inliers[i])
+                            {
+                                feature_match_denormalized fmd;
+                                fmd.pixel_1 = img.features[matches[i].feature_index_1].location;
+                                fmd.pixel_2 = std::get<2>(node_descriptors)[matches[i].feature_index_2].location;
+                                relations.inlier_matches.push_back(fmd);
+                            }
+                        }
+                        inlier_measurements.emplace_back(std::get<0>(node_descriptors), std::move(relations));
+                    }
+                }
+
+                std::lock_guard<std::mutex> graph_lock(_graph_structure_mutex);
+                spdlog::debug("Adding {} edges to node {}", inlier_measurements.size(), node_id);
+                for (auto &node_measurements : inlier_measurements)
+                {
+                    _graph.addEdge(std::move(node_measurements.second), node_id, node_measurements.first);
+                }
+            };
+            funcs.push_back(run_func);
+        }
     }
-    process_links(links);
+    {
+        spdlog::info("Loading batch of {}", paths_to_load.size());
+        for (const auto &path : paths_to_load)
+            spdlog::debug(path);
+//             next_ids = build_nodes(paths_to_load);
+        std::vector<size_t> node_ids;
+        node_ids.reserve(paths_to_load.size());
 
-    initializeOrientation(node_ids, _graph);
+        for (size_t i = 0; i < paths_to_load.size(); i++)
+        {
+            auto run_func = [&, i](){
+                const std::string &path = paths_to_load[i];
+                image img;
+                img.path = path;
+                img.features = extract_features(img.path);
+                if (img.features.size() == 0)
+                {
+                    return;
+                }
 
+                img.metadata = extract_metadata(img.path);
+                img.model.focal_length_pixels = img.metadata.focal_length_px;
+                img.model.pixels_cols = img.metadata.width_px;
+                img.model.pixels_rows = img.metadata.height_px;
+                img.model.principle_point = Eigen::Vector2d(img.model.pixels_cols, img.model.pixels_rows) / 2;
 
+                spdlog::debug("camera model: dims: {}x{} focal: {}", img.model.pixels_cols, img.model.pixels_rows,
+                            img.model.focal_length_pixels);
+
+                std::lock_guard<std::mutex> graph_lock(_graph_structure_mutex);
+                if (!_coordinate_system.isInitialized())
+                {
+                    _coordinate_system.setOrigin(img.metadata.latitude, img.metadata.longitude);
+                }
+                Eigen::Vector3d local_pos = img.position =
+                    _coordinate_system.toLocalCS(img.metadata.latitude, img.metadata.longitude, img.metadata.altitude);
+                size_t node_id = _graph.addNode(std::move(img));
+
+                _imageGPSLocations.addPoint(to_array(local_pos), node_id);
+                node_ids.push_back(node_id);
+            };
+            funcs.push_back(run_func);
+        }
+        
+        // alternate between feature extraction and matching
+        for (size_t i = 0; i*2 < funcs.size(); i+=2) {
+            std::swap(funcs[i], funcs[i*2]);
+        }
+        
+        #pragma omp parallel for schedule(dynamic)
+        for(int i = 0; i < (int)funcs.size(); i++) {
+            funcs[i]();
+        }
+
+        std::lock_guard<std::mutex> graph_lock(_graph_structure_mutex);
+        // sort node_ids by the path, since they may be out of order now
+        std::sort(node_ids.begin(), node_ids.end(), [this](size_t node_id_1, size_t node_id_2) -> int {
+            const auto &path1 = _graph.getNode(node_id_1)->payload.path;
+            const auto &path2 = _graph.getNode(node_id_2)->payload.path;
+            return path1 < path2;
+        });
+        next_ids = node_ids;
+            
+    }
+
+    initializeOrientation(loaded_ids, _graph);
     // TODO:
     // relaxSubset(node_ids, _graph, _graph_structure_mutex);
 }
-std::vector<size_t> Pipeline::build_nodes(const std::vector<std::string> &paths)
-{
-    std::vector<size_t> node_ids;
-    node_ids.reserve(paths.size());
 
-#pragma omp parallel for
-    for (int i = 0; i < (int)paths.size(); i++)
-    {
-        const std::string &path = paths[i];
-        image img;
-        img.path = path;
-        img.features = extract_features(img.path);
-        if (img.features.size() == 0)
-        {
-            continue;
-        }
-
-        img.metadata = extract_metadata(img.path);
-        img.model.focal_length_pixels = img.metadata.focal_length_px;
-        img.model.pixels_cols = img.metadata.width_px;
-        img.model.pixels_rows = img.metadata.height_px;
-        img.model.principle_point = Eigen::Vector2d(img.model.pixels_cols, img.model.pixels_rows) / 2;
-
-        spdlog::debug("camera model: dims: {}x{} focal: {}", img.model.pixels_cols, img.model.pixels_rows,
-                      img.model.focal_length_pixels);
-
-        std::lock_guard<std::mutex> graph_lock(_graph_structure_mutex);
-        if (!_coordinate_system.isInitialized())
-        {
-            _coordinate_system.setOrigin(img.metadata.latitude, img.metadata.longitude);
-        }
-        Eigen::Vector3d local_pos = img.position =
-            _coordinate_system.toLocalCS(img.metadata.latitude, img.metadata.longitude, img.metadata.altitude);
-        size_t node_id = _graph.addNode(std::move(img));
-
-        _imageGPSLocations.addPoint(to_array(local_pos), node_id);
-        node_ids.push_back(node_id);
-    }
-
-    std::lock_guard<std::mutex> graph_lock(_graph_structure_mutex);
-    // sort node_ids by the path, since they may be out of order now
-    std::sort(node_ids.begin(), node_ids.end(), [this](size_t node_id_1, size_t node_id_2) -> int {
-        const auto &path1 = _graph.getNode(node_id_1)->payload.path;
-        const auto &path2 = _graph.getNode(node_id_2)->payload.path;
-        return path1 < path2;
-    });
-
-    return node_ids;
-}
 
 std::vector<Pipeline::NodeLinks> Pipeline::find_links(const std::vector<size_t> &node_ids)
 {
@@ -175,79 +268,7 @@ std::vector<Pipeline::NodeLinks> Pipeline::find_links(const std::vector<size_t> 
     return batch_nearest;
 }
 
-void Pipeline::process_links(const std::vector<NodeLinks> &links)
-{
 
-#pragma omp parallel for
-    for (int i = 0; i < (int)links.size(); i++)
-    {
-        const auto &node_nearest = links[i];
-        size_t node_id = node_nearest.node_id;
-        const auto &img = _graph.getNode(node_id)->payload;
-        const auto &nearest = node_nearest.link_ids;
-
-        // match & distort
-        std::vector<std::tuple<size_t, CameraModel, std::vector<feature_2d>>> nearest_descriptors;
-        nearest_descriptors.reserve(nearest.size());
-        for (size_t match_node_id : nearest)
-        {
-            const auto *node = _graph.getNode(match_node_id);
-            if (node != nullptr)
-            {
-                nearest_descriptors.emplace_back(match_node_id, node->payload.model, node->payload.features);
-            }
-        }
-        std::vector<std::pair<size_t, camera_relations>> inlier_measurements;
-        inlier_measurements.reserve(nearest_descriptors.size());
-        for (const auto &node_descriptors : nearest_descriptors)
-        {
-            // match
-            auto matches = match_features(img.features, std::get<2>(node_descriptors));
-
-            // distort
-            std::vector<correspondence> correspondences = distort_keypoints(
-                img.features, std::get<2>(node_descriptors), matches, img.model, std::get<1>(node_descriptors));
-
-            // ransac
-            homography_model h;
-            std::vector<bool> inliers;
-            ransac(correspondences, h, inliers);
-
-            camera_relations relations;
-            relations.ransac_relation = h.homography;
-            relations.relationType = camera_relations::RelationType::HOMOGRAPHY;
-
-            bool can_decompose =
-                h.decompose(correspondences, inliers, relations.relative_rotation, relations.relative_translation);
-
-            size_t num_inliers = std::count(inliers.begin(), inliers.end(), true);
-
-            spdlog::debug("Matches: {}  inliers: {}  can_decompose: {}", matches.size(), num_inliers, can_decompose);
-            if (can_decompose && num_inliers > h.MINIMUM_POINTS * 1.5)
-            {
-                relations.inlier_matches.reserve(num_inliers);
-                for (size_t i = 0; i < inliers.size(); i++)
-                {
-                    if (inliers[i])
-                    {
-                        feature_match_denormalized fmd;
-                        fmd.pixel_1 = img.features[matches[i].feature_index_1].location;
-                        fmd.pixel_2 = std::get<2>(node_descriptors)[matches[i].feature_index_2].location;
-                        relations.inlier_matches.push_back(fmd);
-                    }
-                }
-                inlier_measurements.emplace_back(std::get<0>(node_descriptors), std::move(relations));
-            }
-        }
-
-        std::lock_guard<std::mutex> graph_lock(_graph_structure_mutex);
-        spdlog::debug("Adding {} edges to node {}", inlier_measurements.size(), node_id);
-        for (auto &node_measurements : inlier_measurements)
-        {
-            _graph.addEdge(std::move(node_measurements.second), node_id, node_measurements.first);
-        }
-    }
-}
 
 void Pipeline::add(const std::vector<std::string> &paths)
 {


### PR DESCRIPTION
Due to the way the batches worked, all the images were loaded, then all the matching was done, per batch. This runs these tasks in parallel inside of the batch to free up IO bottlenecks, and also allow better usage of diverse silicon (POPCNT vs FPU, etc)